### PR TITLE
Change logic for "max_row" count

### DIFF
--- a/Xls/Reader/PythonReader.php
+++ b/Xls/Reader/PythonReader.php
@@ -15,6 +15,8 @@ class PythonReader extends ReaderAbstract implements ReaderInterface
     const COMMAND_GET_COUNT = "count";
     const COMMAND_READ_CHUNk = "read";
 
+    const MAX_COUNT_EMPTY_ROWS = 100;
+
     /** @var string */
     private $pythonExecutable;
 
@@ -43,9 +45,13 @@ class PythonReader extends ReaderAbstract implements ReaderInterface
     }
 
     /** {@inheritdoc} */
-    public function getRowsNumber($path)
+    public function getRowsNumber($path, $maxCountEmptyRows = null)
     {
-        return intval($this->executeCommand(self::COMMAND_GET_COUNT, $path));
+        return intval($this->executeCommand(
+            self::COMMAND_GET_COUNT,
+            $path,
+            "--max-empty-rows=" . (is_null($maxCountEmptyRows) ? self::MAX_COUNT_EMPTY_ROWS : $maxCountEmptyRows)
+        ));
     }
 
     /**

--- a/Xls/Reader/ReaderInterface.php
+++ b/Xls/Reader/ReaderInterface.php
@@ -26,9 +26,10 @@ interface ReaderInterface
 
     /**
      * @param string $path
+     * @param int $maxCountEmptyRows
      * @return \Iterator
      */
-    public function getRowsNumber($path);
+    public function getRowsNumber($path, $maxCountEmptyRows = null);
 
     /**
      * @param string $path

--- a/Xls/Reader/excel_openpyxl.py
+++ b/Xls/Reader/excel_openpyxl.py
@@ -5,12 +5,14 @@ import os
 import argparse
 import datetime
 
+
 def run(argv):
   parser = argparse.ArgumentParser()
   parser.add_argument('--size')
   parser.add_argument('--start')
   parser.add_argument('--action')
   parser.add_argument('--file')
+  parser.add_argument('--max-empty-rows', dest="max_empty_rows")
   args = parser.parse_args()
 
   if False == os.path.isfile(args.file):
@@ -20,7 +22,27 @@ def run(argv):
   workbook = load_workbook(args.file, read_only=True)
   sheet = workbook.active
   if args.action == "count":
-    print(sheet.max_row)
+    max_count_empty_rows = int(args.max_empty_rows)
+    sheet.max_row = None
+    rows_count = 0
+    empty_rows_count = 0
+    for row in sheet.iter_rows(row_offset=int(1) - 1):
+      current_row_read = []
+      for cell in row:
+        value = cell.value
+        if value is None:
+          continue
+        else:
+          current_row_read.append(True)
+          empty_rows_count = 0
+          break
+      if not current_row_read:
+        empty_rows_count += 1
+      else:
+        rows_count += 1
+      if max_count_empty_rows < empty_rows_count:
+        break
+    print(rows_count)
   elif args.action == "read":
     rows = []
     for row in sheet.iter_rows(row_offset=int(args.start) - 1):


### PR DESCRIPTION
`sheet.max_row` just take count from description of file. But, sometimes, we have rows with some functionality, formulas, styles. And `max_row` count it too. In this PR, I've added counting rows by iterating it.