### PR TITLE
Fix empty argument "max-empty-rows" in xls script

### DIFF
--- a/Xls/Reader/excel_xlrd.py
+++ b/Xls/Reader/excel_xlrd.py
@@ -10,6 +10,7 @@ def run(argv):
   parser.add_argument('--start')
   parser.add_argument('--action')
   parser.add_argument('--file')
+  parser.add_argument('--max-empty-rows', dest="max_empty_rows")
   args = parser.parse_args()
 
   if False == os.path.isfile(args.file):


### PR DESCRIPTION
We send argument "max-empty-rows" to two different script. In xls need to set, that this argument is available